### PR TITLE
Fix for having no config file

### DIFF
--- a/rotate-backups.py
+++ b/rotate-backups.py
@@ -149,13 +149,13 @@ class SimpleConfig(object):
       r = None
 
       if self.config.has_section('Settings'):
-          if setting in ('hourly_backup_hour', 'weekly_backup_day', 'max_weekly_backups'):
-              r = self.config.getint('Settings', setting)
-          else:
-              r = self.config.get('Settings', setting)
+         if setting in ('hourly_backup_hour', 'weekly_backup_day', 'max_weekly_backups'):
+            r = self.config.getint('Settings', setting)
+         else:
+            r = self.config.get('Settings', setting)
 
       if setting == 'backup_extensions':
-          r = self.parse_extensions(r)
+         r = self.parse_extensions(r)
 
       return r or DEFAULTS.get(setting)
 


### PR DESCRIPTION
This is for running without a config file. This change checks for a Settings section, which won't exist because the config file does not exist, otherwise exceptions are thrown and the script will not run.
