### PR TITLE
Rename format_filename

### DIFF
--- a/rotate-backups.py
+++ b/rotate-backups.py
@@ -231,15 +231,15 @@ class Backup(object):
       # Does the filename include a date?
       path_parts = os.path.split(self.path_to_file)
       filename = path_parts[-1]
-      parent_dir = os.sep + os.path.join(*path_parts[:-1])
 
       if not re.match(file_pattern, filename.split('.')[0]):
           # No date, rename the file.
-          self.mtime = time.localtime( os.path.getmtime(self.path_to_file) )
-          self.mtime_str = time.strftime('%Y-%m-%d-%H%M', self.mtime)
+          mtime = time.localtime( os.path.getmtime(self.path_to_file) )
+          mtime_str = time.strftime('%Y-%m-%d-%H%M', mtime)
           account = filename.split('.')[0]
           extension = filename.split('.', 1)[1]
-          filename = ('%s-%s.' + extension) % (account, self.mtime_str)
+          filename = ('%s-%s.' + extension) % (account, mtime_str)
+          parent_dir = os.sep + os.path.join(*path_parts[:-1])
           new_filepath = os.path.join(parent_dir, filename)
           LOGGER.info('Renaming file to %s.' % new_filepath)
           shutil.move(self.path_to_file, new_filepath)

--- a/rotate-backups.py
+++ b/rotate-backups.py
@@ -258,14 +258,10 @@ def is_backup(filename, backup_extensions):
           return True
    return False
 
-def collect(archives_dir):
-   """Return a collection of account objects for all accounts in backup directory."""
-   accounts = []
-   # Append all account names from archives_dir.
-   for account_name in os.listdir(archives_dir):
-      accounts.append(account_name)
-   accounts = sorted(list(set(accounts))) # Uniquify.
-   return accounts
+
+def get_sorted_dirs(directory):
+   """Returns sorted dirnames in a directory"""
+   return sorted(list(set(os.listdir(directory)))
 
 
 def check_dirs(backups_dir, archives_dir):
@@ -282,6 +278,7 @@ def check_dirs(backups_dir, archives_dir):
          LOGGER.error("Unable to create archives directory: %s." % archives_dir)
          sys.exit(1)
 
+
 def rotate_new_arrivals(backups_dir, archives_dir, backup_extensions, period_name):
    for filename in os.listdir(backups_dir):
       if is_backup(filename, backup_extensions=backup_extensions):
@@ -296,7 +293,6 @@ def is_rotation_time(
   weekly_backup_day,
 ):
   assert(period_name in ('hourly', 'daily', 'weekly'))
-
   if period_name == 'hourly':
      actual_time = date.hour
      config_time = hourly_backup_hour
@@ -305,7 +301,6 @@ def is_rotation_time(
      config_time = weekly_backup_day
   else:
      return False
-
   if actual_time == config_time:
      LOGGER.debug('%s equals %s.' % (actual_time, config_time))
      return True
@@ -342,7 +337,6 @@ def rotate(
 
 try:
   import pytest
-
   import tempfile
 
 
@@ -459,12 +453,12 @@ def do_move_to_archive_and_rotate(
     period_name='hourly',
   )
 
-  for account_name in collect(archives_dir=archives_dir):
+  for dirname in get_sorted_dirs(directory=archives_dir):
     kw = dict(
       archives_dir=archives_dir,
       hourly_backup_hour=hourly_backup_hour,
       weekly_backup_day=weekly_backup_day,
-      account_name=account_name,
+      account_name=dirname,
     )
 
     rotate(

--- a/rotate-backups.py
+++ b/rotate-backups.py
@@ -486,8 +486,8 @@ def do_move_to_archive_and_rotate(
 def get_parser():
   import argparse
   parser = argparse.ArgumentParser()
-  parser.add_argument("--backups-dir", help="Directory to store rotated files", type=str)
-  parser.add_argument("--archives-dir", help="Source directory for new files", type=str)
+  parser.add_argument("--backups-dir", help="Source directory for new files", type=str)
+  parser.add_argument("--archives-dir", help="Directory to store rotated files", type=str)
   # parser.add_argument("--backup-extensions", help="Extensions to interpret as backup files, comma separated", type=str)
   return parser
 

--- a/rotate-backups.py
+++ b/rotate-backups.py
@@ -483,17 +483,30 @@ def do_move_to_archive_and_rotate(
     )
 
 
-if __name__ == '__main__':
+def get_parser():
   import argparse
   parser = argparse.ArgumentParser()
-  parser.add_argument("--noconfig", help="don't look for config file", action="store_true")
-  args = parser.parse_args()
+  parser.add_argument("--backups-dir", help="Directory to store rotated files", type=str)
+  parser.add_argument("--archives-dir", help="Source directory for new files", type=str)
+  # parser.add_argument("--backup-extensions", help="Extensions to interpret as backup files, comma separated", type=str)
+  return parser
 
+
+def update_config_with_args(config):
+  args = get_parser().parse_args()
+  if args.backups_dir:
+    config['backups_dir'] = os.path.abspath(args.backups_dir)
+  if args.archives_dir:
+    config['archives_dir'] = os.path.abspath(args.archives_dir)
+  # if args.backup_extensions:
+  #   config['backup_extensions'] = args.backup_extensions.split(',')
+
+
+if __name__ == '__main__':
   config = SimpleConfig().config.__dict__['_sections']['Settings']
   config['max_weekly_backups'] = int(config['max_weekly_backups'])
   config['hourly_backup_hour'] = int(config['hourly_backup_hour'])
   config['weekly_backup_day'] = int(config['weekly_backup_day'])
-
+  update_config_with_args(config)
   do_move_to_archive_and_rotate(**config)
-
   sys.exit(0)

--- a/rotate-backups.py
+++ b/rotate-backups.py
@@ -190,16 +190,18 @@ def get_backups_in(account_name, directory, archives_dir):
   return backups
 
 
+file_pattern = '(.*)(\-)([0-9]{4}\-[0-9]{2}\-[0-9]{2}\-[0-9]{4})'
+
+
 class Backup(object):
    def __init__(self, path_to_file):
       """Instantiation also rewrites the filename if not already done, prepending the date."""
-      self.pattern = '(.*)(\-)([0-9]{4}\-[0-9]{2}\-[0-9]{2}\-[0-9]{4})'
       self.path_to_file = path_to_file
       self.filename = self.format_filename()
       self.set_account_and_date(self.filename)
 
    def set_account_and_date(self, filename):
-      match_obj = re.match(self.pattern, filename)
+      match_obj = re.match(file_pattern, filename)
       if match_obj is None:
         return filename
       self.account = match_obj.group(1)
@@ -230,7 +232,8 @@ class Backup(object):
       path_parts = os.path.split(self.path_to_file)
       filename = path_parts[-1]
       parent_dir = os.sep + os.path.join(*path_parts[:-1])
-      if not re.match(self.pattern, filename.split('.')[0]):
+
+      if not re.match(file_pattern, filename.split('.')[0]):
           # No date, rename the file.
           self.mtime = time.localtime( os.path.getmtime(self.path_to_file) )
           self.mtime_str = time.strftime('%Y-%m-%d-%H%M', self.mtime)
@@ -241,6 +244,7 @@ class Backup(object):
           LOGGER.info('Renaming file to %s.' % new_filepath)
           shutil.move(self.path_to_file, new_filepath)
           self.path_to_file = new_filepath
+
       return filename
 
    def __cmp__(x, y):

--- a/rotate-backups.py
+++ b/rotate-backups.py
@@ -183,9 +183,9 @@ def get_backups_in(account_name, directory, archives_dir):
   path_to_dir = '%s%s/' % (base_path, directory)
   backups = []
   if os.path.isdir(path_to_dir):
-     for filename in os.listdir(path_to_dir):
-        path_to_file = os.path.join(path_to_dir, filename)
-        backups.append(Backup(path_to_file))
+    for filename in os.listdir(path_to_dir):
+      path_to_file = os.path.join(path_to_dir, filename)
+      backups.append(Backup(path_to_file))
   backups.sort(key=lambda b: b.date)
   return backups
 


### PR DESCRIPTION
After the `if not re.match(file_pattern, filename.split('.')[0])``
 part the file is moved.
The method name``format_filename`` suggests that a formatted string is returned.

I didn't change the functionality but renamed the method to the function and removed the "self." reassignments.

In a next step, I think `if match_obj is None:` should be removed from set_account_and_date.
What do you think?
